### PR TITLE
Add compatibility with vpm-resolver v0.1.17

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -18,7 +18,7 @@
             "Assets\\QvPen": "0eeec8527d6948040915b97bddf0ba10"
           },
           "unity": "2019.4",
-          "url": "https://github.com/ureishi/QvPen/releases/download/v3.2.6/net.ureishi.qvpen-3.2.6.zip",
+          "url": "https://github.com/ureishi/QvPen/releases/download/v3.2.6/net.ureishi.qvpen-3.2.6.zip?",
           "vpmDependencies": {
             "com.vrchat.udonsharp": "1.1.7"
           }


### PR DESCRIPTION
Because of [this](https://github.com/vrchat-community/creator-companion/issues/226) issue, we need trailing '?' at the end of zip link.